### PR TITLE
Check netlink errors not msgcount

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/kataras/go-events v0.0.3-0.20170604004442-17d67be645c3
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
-	github.com/mdlayher/netlink v0.0.0-20191009155606-de872b0d824b
+	github.com/mdlayher/netlink v1.0.0
 	github.com/michaelquigley/pfxlog v0.0.0-20190813191113-2be43bd0dccc
 	github.com/miekg/dns v1.1.22
 	github.com/mitchellh/mapstructure v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
-github.com/mdlayher/netlink v0.0.0-20191009155606-de872b0d824b h1:W3er9pI7mt2gOqOWzwvx20iJ8Akiqz1mUMTxU6wdvl8=
-github.com/mdlayher/netlink v0.0.0-20191009155606-de872b0d824b/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
+github.com/mdlayher/netlink v1.0.0 h1:vySPY5Oxnn/8lxAPn2cK6kAzcZzYJl3KriSLO46OT18=
+github.com/mdlayher/netlink v1.0.0/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/michaelquigley/pfxlog v0.0.0-20190813191113-2be43bd0dccc h1:PQrqw9XKYcPRI9rKwoGZucMjWvfZpyfb5j8Lc13j8YY=

--- a/tunnel/router/router_linux.go
+++ b/tunnel/router/router_linux.go
@@ -120,9 +120,11 @@ func nlAddrReq(localPrefix, peerPrefix *net.IPNet, ifName string, t netlink.Head
 
 	_, err = c.Execute(req)
 	if err != nil {
-		nlErr := err.(*netlink.OpError)
-		if os.IsExist(nlErr.Err) {
-			return nil
+		switch err.(type) {
+		case *netlink.OpError:
+			if os.IsExist(err.(*netlink.OpError).Err) {
+				return nil
+			}
 		}
 	}
 

--- a/tunnel/router/router_linux.go
+++ b/tunnel/router/router_linux.go
@@ -17,6 +17,7 @@
 package router
 
 import (
+	"errors"
 	"fmt"
 	"github.com/mdlayher/netlink"
 	"github.com/mdlayher/netlink/nlenc"
@@ -120,9 +121,9 @@ func nlAddrReq(localPrefix, peerPrefix *net.IPNet, ifName string, t netlink.Head
 
 	_, err = c.Execute(req)
 	if err != nil {
-		switch err.(type) {
-		case *netlink.OpError:
-			if os.IsExist(err.(*netlink.OpError).Err) {
+		var nlErr *netlink.OpError
+		if errors.As(err, &nlErr) {
+			if os.IsExist(nlErr.Err) {
 				return nil
 			}
 		}


### PR DESCRIPTION
This PR fixes the netlink errors that cropped up recently in ziti-tunnel:

    failed to add local route: expected 1 netlink message, but got 0

This seemed to be benign at first glance, since the routes actually _were_ being added, but it was a problem for ziti-tunnel because it prevented the intercept setup from completing for a given service.

I didn't figure out why the problem started all of a sudden, but I'm guessing that it has something to do with vendored dependencies changing as we shifted to modules. Anyway, clients of the netlink package that we're using simply check the err returned by the Execute method.