### PR TITLE
fixes #158, auth/enroll cleared on update

### DIFF
--- a/controller/internal/routes/authenticator_router.go
+++ b/controller/internal/routes/authenticator_router.go
@@ -83,6 +83,10 @@ func (ir *AuthenticatorRouter) Patch(ae *env.AppEnv, rc *response.RequestContext
 			fields.AddField("salt")
 		}
 
+		if fields.IsUpdated("certPem") {
+			fields.AddField("fingerprint")
+		}
+
 		return ae.Handlers.Authenticator.Patch(apiEntity.ToModel(id), fields.FilterMaps("tags"))
 	})
 }

--- a/controller/model/identity_handlers.go
+++ b/controller/model/identity_handlers.go
@@ -185,7 +185,7 @@ func (handler *IdentityHandler) Delete(id string) error {
 }
 
 func (handler IdentityHandler) IsUpdated(field string) bool {
-	return field != "Authenticators" && field != "Enrollments" && field != "IsDefaultAdmin"
+	return field != persistence.FieldIdentityAuthenticators && field != persistence.FieldIdentityEnrollments && field != persistence.FieldIdentityIsDefaultAdmin
 }
 
 func (handler *IdentityHandler) Read(id string) (*Identity, error) {

--- a/controller/persistence/authenticator_store.go
+++ b/controller/persistence/authenticator_store.go
@@ -71,10 +71,11 @@ type Authenticator struct {
 }
 
 var authenticatorFieldMappings = map[string]string{
-	FieldAuthenticatorIdentity:     "identityId",
-	FieldAuthenticatorUpdbPassword: "password",
-	FieldAuthenticatorUpdbUsername: "username",
-	FieldAuthenticatorUpdbSalt:     "salt"}
+	FieldAuthenticatorIdentity:        "identityId",
+	FieldAuthenticatorUpdbPassword:    "password",
+	FieldAuthenticatorUpdbUsername:    "username",
+	FieldAuthenticatorUpdbSalt:        "salt",
+	FieldAuthenticatorCertFingerprint: "fingerprint"}
 
 func (entity *Authenticator) LoadValues(_ boltz.CrudStore, bucket *boltz.TypedBucket) {
 	entity.Type = bucket.GetStringOrError(FieldAuthenticatorMethod)

--- a/controller/persistence/migration_v6.go
+++ b/controller/persistence/migration_v6.go
@@ -1,0 +1,73 @@
+/*
+	Copyright NetFoundry, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package persistence
+
+import (
+	"fmt"
+	"github.com/netfoundry/ziti-foundation/storage/boltz"
+)
+
+func (m *Migrations) fixIdentityBuckets(step *boltz.MigrationStep) {
+	identityIds, _, err := m.stores.Identity.QueryIds(step.Ctx.Tx(), "true")
+	step.SetError(err)
+
+	for _, identityId := range identityIds {
+		identity, err := m.stores.Identity.LoadOneById(step.Ctx.Tx(), identityId)
+
+		if step.SetError(err) {
+			return
+		}
+
+		authIds, _, err := m.stores.Authenticator.QueryIds(step.Ctx.Tx(), fmt.Sprintf(`identity="%s"`, identity.Id))
+		if step.SetError(err) {
+			return
+		}
+
+		if len(authIds) != len(identity.Authenticators) {
+			for _, authId := range authIds {
+				authenticator, err := m.stores.Authenticator.LoadOneById(step.Ctx.Tx(), authId)
+				if step.SetError(err) {
+					return
+				}
+
+				err = m.stores.Authenticator.DeleteById(step.Ctx, authenticator.Id)
+				if step.SetError(err) {
+					return
+				}
+
+				err = m.stores.Authenticator.Create(step.Ctx, authenticator)
+				if step.SetError(err) {
+					return
+				}
+			}
+		}
+
+		enrollIds, _, err := m.stores.Enrollment.QueryIds(step.Ctx.Tx(), fmt.Sprintf(`identity="%s"`, identity.Id))
+		if step.SetError(err) {
+			return
+		}
+
+		if len(enrollIds) != len(identity.Enrollments) {
+			for _, enrolId := range enrollIds {
+				err = m.stores.Enrollment.DeleteById(step.Ctx, enrolId)
+				if step.SetError(err) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/controller/persistence/migrations.go
+++ b/controller/persistence/migrations.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	CurrentDbVersion = 4
+	CurrentDbVersion = 6
 	FieldVersion     = "version"
 )
 
@@ -67,9 +67,15 @@ func (m *Migrations) migrate(step *boltz.MigrationStep) int {
 		m.createEnrollmentsForEdgeRouters(step)
 		return 5
 	}
-	// current version
+
 	if step.CurrentVersion == 5 {
-		return 5
+		m.fixIdentityBuckets(step)
+		return 6
+	}
+
+	// current version
+	if step.CurrentVersion == 6 {
+		return 6
 	}
 
 	step.SetError(errors.Errorf("Unsupported edge datastore version: %v", step.CurrentVersion))

--- a/internal/cert/fingerprint.go
+++ b/internal/cert/fingerprint.go
@@ -69,7 +69,14 @@ type defaultFingerprintGenerator struct{}
 func firstCertBlock(pemBytes []byte) (*pem.Block, []byte) {
 	var block *pem.Block
 	for len(pemBytes) > 0 {
+		pemLength := len(pemBytes)
 		block, pemBytes = pem.Decode(pemBytes)
+
+		if pemLength == len(pemBytes) {
+			//pem isn't parsing, we received not blocks, pemBytes should shrink on each Decode()
+			return nil, nil
+		}
+
 		if block == nil {
 			continue
 		}

--- a/internal/pem/pem_test.go
+++ b/internal/pem/pem_test.go
@@ -1,0 +1,13 @@
+package pem
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_firstCertBlock(t *testing.T) {
+	t.Run("returns nil on invalid PEM content", func(t *testing.T) {
+		ret := firstCertBlock([]byte("123456790123456790123456790123456790123456790123456790123456790123456790"))
+		require.New(t).Nil(ret)
+	})
+}

--- a/tests/auth_cert_test.go
+++ b/tests/auth_cert_test.go
@@ -74,7 +74,7 @@ func (test *authCertTests) testAuthenticateCertStoresAndFillsFullCert(t *testing
 		r.NotEmpty(certAuth.Pem, "cert authenticator pem was empty/blank")
 	})
 
-	t.Run("cert authenticators with no blank pem is stored on authenticate", func(t *testing.T) {
+	t.Run("cert authenticators with blank pem is stored on authenticate", func(t *testing.T) {
 		r := require.New(t)
 		authenticator, err := test.ctx.EdgeController.AppEnv.Handlers.Authenticator.ReadByFingerprint(test.certAuthenticator.Fingerprint())
 

--- a/tests/authenticate.go
+++ b/tests/authenticate.go
@@ -297,6 +297,26 @@ func (request *authenticatedRequests) requireCreateIdentityOttEnrollment(name st
 	return id, request.testContext.completeOttEnrollment(id)
 }
 
+func (request *authenticatedRequests) requireCreateIdentityOttEnrollmentUnfinished(name string, isAdmin bool, rolesAttributes ...string) string {
+	entityData := gabs.New()
+	request.testContext.setJsonValue(entityData, name, "name")
+	request.testContext.setJsonValue(entityData, "User", "type")
+	request.testContext.setJsonValue(entityData, isAdmin, "isAdmin")
+	request.testContext.setJsonValue(entityData, rolesAttributes, "roleAttributes")
+
+	enrollments := map[string]interface{}{
+		"ott": true,
+	}
+	request.testContext.setJsonValue(entityData, enrollments, "enrollment")
+
+	entityJson := entityData.String()
+	resp := request.createEntityOfType("identities", entityJson)
+	request.testContext.req.Equal(http.StatusCreated, resp.StatusCode())
+	id := request.testContext.getEntityId(resp.Body())
+	request.testContext.req.NotEmpty(id)
+	return id
+}
+
 func (request *authenticatedRequests) requireNewService(roleAttributes, configs []string) *service {
 	service := request.testContext.newService(roleAttributes, configs)
 	request.requireCreateEntity(service)

--- a/tests/identity_test.go
+++ b/tests/identity_test.go
@@ -19,7 +19,9 @@
 package tests
 
 import (
+	"github.com/Jeffail/gabs"
 	"github.com/netfoundry/ziti-foundation/util/stringz"
+	"net/http"
 	"net/url"
 	"sort"
 	"testing"
@@ -89,5 +91,111 @@ func Test_Identity(t *testing.T) {
 		ctx.req.True(len(list) >= 4)
 		ctx.req.True(stringz.ContainsAll(list, role1, role2, role3, role4))
 		ctx.req.False(stringz.Contains(list, role5))
+	})
+
+	t.Run("update (PUT) an identity", func(t *testing.T) {
+		ctx.testContextChanged(t)
+		enrolledId, _ := ctx.AdminSession.requireCreateIdentityOttEnrollment(uuid.New().String(), false)
+		enrolledIdentity := ctx.AdminSession.requireQuery("identities/" + enrolledId)
+
+		unenrolledId := ctx.AdminSession.requireCreateIdentityOttEnrollmentUnfinished(uuid.New().String(), false)
+		unenrolledIdentity := ctx.AdminSession.requireQuery("identities/" + unenrolledId)
+
+		t.Run("should not alter authenticators", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			updateContent := gabs.New()
+			_, _ = updateContent.SetP(uuid.New().String(), "name")
+			_, _ = updateContent.SetP("Device", "type")
+			_, _ = updateContent.SetP(map[string]interface{}{}, "tags")
+			_, _ = updateContent.SetP(false, "isAdmin")
+
+			resp := ctx.AdminSession.updateEntityOfType(enrolledId, "identities", updateContent.String(), false)
+			ctx.req.Equal(http.StatusOK, resp.StatusCode())
+
+			updatedIdentity := ctx.AdminSession.requireQuery("identities/" + enrolledId)
+
+			data := enrolledIdentity.Path("data.authenticators").Data()
+			expectedAuths := data.(map[string]interface{})
+			ctx.req.NotEmpty(expectedAuths)
+
+			updatedAuths := updatedIdentity.Path("data.authenticators").Data().(map[string]interface{})
+			ctx.req.NotEmpty(updatedAuths)
+			ctx.req.Equal(expectedAuths, updatedAuths)
+		})
+
+		t.Run("should not alter enrollments", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			updateContent := gabs.New()
+			_, _ = updateContent.SetP(uuid.New().String(), "name")
+			_, _ = updateContent.SetP("Device", "type")
+			_, _ = updateContent.SetP(map[string]interface{}{}, "tags")
+			_, _ = updateContent.SetP(false, "isAdmin")
+
+			resp := ctx.AdminSession.updateEntityOfType(unenrolledId, "identities", updateContent.String(), false)
+			ctx.req.Equal(http.StatusOK, resp.StatusCode())
+
+			updatedIdentity := ctx.AdminSession.requireQuery("identities/" + unenrolledId)
+
+			expectedEnrollments := unenrolledIdentity.Path("data.enrollment").Data().(map[string]interface{})
+			ctx.req.NotEmpty(expectedEnrollments)
+
+			updatedEnrollments := updatedIdentity.Path("data.enrollment").Data().(map[string]interface{})
+			ctx.req.NotEmpty(updatedEnrollments)
+
+			ctx.req.Equal(expectedEnrollments, updatedEnrollments)
+		})
+
+		t.Run("should not allow isDefaultAdmin to be altered", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			identityId := ctx.AdminSession.requireCreateIdentity(uuid.New().String(), true)
+
+			updateContent := gabs.New()
+			_, _ = updateContent.SetP(uuid.New().String(), "name")
+			_, _ = updateContent.SetP("Device", "type")
+			_, _ = updateContent.SetP(map[string]interface{}{}, "tags")
+			_, _ = updateContent.SetP(true, "isAdmin")
+			_, _ = updateContent.SetP(true, "isDefaultAdmin")
+
+			resp := ctx.AdminSession.updateEntityOfType(identityId, "identities", updateContent.String(), false)
+			ctx.req.Equal(http.StatusOK, resp.StatusCode())
+
+			updatedIdentity := ctx.AdminSession.requireQuery("identities/" + unenrolledId)
+
+			ctx.req.Equal(true, updatedIdentity.ExistsP("data.isDefaultAdmin"))
+			isDefaultAdmin := updatedIdentity.Path("data.isDefaultAdmin").Data().(bool)
+			ctx.req.Equal(false, isDefaultAdmin)
+		})
+
+		t.Run("can update", func(t *testing.T) {
+			ctx.testContextChanged(t)
+			identityId := ctx.AdminSession.requireCreateIdentity(uuid.New().String(), true)
+
+			newName := uuid.New().String()
+			updateContent := gabs.New()
+			_, _ = updateContent.SetP(newName, "name")
+			_, _ = updateContent.SetP("Device", "type")
+			_, _ = updateContent.SetP(map[string]interface{}{}, "tags")
+			_, _ = updateContent.SetP(false, "isAdmin")
+
+			resp := ctx.AdminSession.updateEntityOfType(identityId, "identities", updateContent.String(), false)
+			ctx.req.Equal(http.StatusOK, resp.StatusCode())
+
+			updatedIdentity := ctx.AdminSession.requireQuery("identities/" + identityId)
+
+			t.Run("name", func(t *testing.T) {
+				ctx.testContextChanged(t)
+				ctx.req.Equal(true, updatedIdentity.ExistsP("data.name"))
+				updatedName := updatedIdentity.Path("data.name").Data().(string)
+				ctx.req.Equal(newName, updatedName)
+			})
+
+			t.Run("isAdmin", func(t *testing.T) {
+				ctx.testContextChanged(t)
+				ctx.req.Equal(true, updatedIdentity.ExistsP("data.isAdmin"))
+				newIsAdmin := updatedIdentity.Path("data.isAdmin").Data().(bool)
+				ctx.req.Equal(false, newIsAdmin)
+			})
+		})
+
 	})
 }


### PR DESCRIPTION
- update for identities does not allow enroll/auth/default admin to be
  updated/cleared accidentally
- adds migrations to fix broken data models between ident/auth/enrol
- fixes migration not to be stuck at version 4